### PR TITLE
Update sites.go

### DIFF
--- a/api/sites.go
+++ b/api/sites.go
@@ -18,7 +18,7 @@ type SiteResult struct {
 }
 
 func (c *Client) GetSites(values url.Values) (data []*Site, err error) {
-	req, err := c.NewRequest("GET", "v2.1/sites?"+values.Encode(), nil)
+	req, err := c.NewRequest("GET", "v2.1/sites?state=active&"+values.Encode(), nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Filter only for active sites.
If a site exists multiple times (e.g. when deleted) the check will fail.