### PR TITLE
d in SiteId is now expected in lowercase

### DIFF
--- a/check.go
+++ b/check.go
@@ -76,7 +76,7 @@ func (c *Config) Run() (rc int, output string, err error) {
 			return
 		}
 
-		values.Set("siteIDs", siteID)
+		values.Set("siteIds", siteID)
 	}
 
 	if c.ComputerName != "" {


### PR DESCRIPTION
Check stopped working some days ago, producing a "segmentation fault". Took a look at the API docs of S1 and changed the `d` in `SiteId` to lowercase. That makes the check work again

```
[UNKNOWN] - HTTP request returned non-ok status 400 Bad Request - Validation Error: dict_values(['siteIDs']): Unknown field (*errors.errorString)
```