### PR TITLE
filter threats that don't belong to specified ComputerName

### DIFF
--- a/api/threats.go
+++ b/api/threats.go
@@ -36,7 +36,7 @@ type ThreatInfo struct {
 	MitigationStatusDescription string    `json:"mitigationStatusDescription"`
 }
 
-func (c *Client) GetThreats(values url.Values) (threats []*Threat, err error) {
+func (c *Client) GetThreats(values url.Values, computername string) (threats []*Threat, err error) {
 	// nolint: noctx
 	req, err := c.NewRequest("GET", "v2.1/threats?"+values.Encode(), nil)
 	if err != nil {
@@ -55,7 +55,9 @@ func (c *Client) GetThreats(values url.Values) (threats []*Threat, err error) {
 		if err != nil {
 			return
 		}
-
+		if computername != "" && computername != t.AgentRealtimeInfo.AgentComputerName {
+			continue
+		}
 		threats = append(threats, t)
 	}
 

--- a/check.go
+++ b/check.go
@@ -83,7 +83,7 @@ func (c *Config) Run() (rc int, output string, err error) {
 		values.Set("computerName__contains", c.ComputerName)
 	}
 
-	threats, err := client.GetThreats(values)
+	threats, err := client.GetThreats(values, c.ComputerName)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
As the SentinelOne API parameter `computerName__contains` is not an exact match when filtering threats for specific ComputerNames, I updated the `GetThreats` function to ignore any threats that don't match the given ComputerName via the `--computer-name` parameter.

Current behavior for reference:
`--computer-name "abc-job01"`
Get's threats for hosts like `abc-job01` but also for `abc-job01_whatever` (and so on).

If parameter `--computer-name` is not supplied, the function will gather all threats for the site

