### PR TITLE
Make HTTP client timeout configurable via existing -t/--timeout flag

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
-const DefaultTimeout = 5
+const DefaultTimeout = 5 * time.Second
 
 type Client struct {
 	AuthConfig    *clientcredentials.Config
@@ -18,14 +18,18 @@ type Client struct {
 	AuthToken     string
 }
 
-func NewClient(url, token string) (c *Client) {
+func NewClient(url, token string, timeout time.Duration) (c *Client) {
 	c = &Client{
 		ManagementURL: url,
 		AuthToken:     token,
 	}
 
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
 	c.HTTPClient = NewLoggingHTTPClient()
-	c.HTTPClient.Timeout = time.Duration(DefaultTimeout) * time.Second
+	c.HTTPClient.Timeout = timeout
 
 	return
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -16,13 +16,13 @@ func envClient(t *testing.T) *api.Client {
 		t.Skip("SENTINELONE_URL and SENTINELONE_TOKEN must be set!")
 	}
 
-	return api.NewClient(url, token)
+	return api.NewClient(url, token, 0)
 }
 
 func testClient() (*api.Client, func()) {
 	httpmock.Activate()
 
-	return api.NewClient("https://euce1-test.sentinelone.net", "test"), func() {
+	return api.NewClient("https://euce1-test.sentinelone.net", "test", 0), func() {
 		httpmock.DeactivateAndReset()
 	}
 }

--- a/check.go
+++ b/check.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/NETWAYS/check_sentinelone/api"
 	"github.com/NETWAYS/go-check"
@@ -19,6 +20,7 @@ type Config struct {
 	IgnoreInProgress bool
 	SiteName         string
 	ComputerName     string
+	Timeout          time.Duration
 }
 
 func BuildConfigFlags(fs *pflag.FlagSet) (config *Config) {
@@ -58,7 +60,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Run() (*result.PartialResult, error) {
-	client := api.NewClient(c.ManagementURL, c.AuthToken)
+	client := api.NewClient(c.ManagementURL, c.AuthToken, c.Timeout)
 
 	values := url.Values{}
 	values.Set("sortOrder", "desc")

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/NETWAYS/go-check"
 	"github.com/NETWAYS/go-check/result"
 )
@@ -26,6 +28,8 @@ func main() {
 	config := BuildConfigFlags(plugin.FlagSet)
 	plugin.ParseArguments()
 	config.SetFromEnv()
+
+	config.Timeout = time.Duration(plugin.Timeout) * time.Second
 
 	err := config.Validate()
 	if err != nil {


### PR DESCRIPTION
## Problem

The HTTP client used internally in `api/client.go` had a hardcoded timeout
of 5 seconds (`DefaultTimeout = 5`), completely independent of the
`-t/--timeout` flag exposed via the go-check library (defaults to 30s).

As soon as a request to the SentinelOne API takes longer than 5 seconds,
the check fails with:

    HTTP request failed: Get "...": context deadline exceeded
    (Client.Timeout exceeded while awaiting headers)

...no matter what value is passed via `-t`. We ran into this in
production: our SentinelOne threats query started taking ~11-12s to
respond (confirmed independently via curl, which succeeded fine), while
the plugin kept failing every single time, since 11s > the hardcoded 5s.

## Fix

- `api.NewClient()` now takes an explicit `timeout time.Duration`
  parameter instead of relying on the hardcoded constant.
- `Config` (in `check.go`) gets a `Timeout time.Duration` field, passed
  through to `api.NewClient()`.
- `main.go` sets `config.Timeout` from `plugin.Timeout` (the existing
  `-t/--timeout` flag) after parsing arguments.
- `DefaultTimeout` (5s) is kept as-is and only used as a fallback if
  `NewClient` is called with a zero/negative duration.

This is a minimal, behavior-preserving change: the effective default
timeout stays the same (30s from the existing flag default), but it's
now actually possible to tune it.

## Testing

Verified locally against a real SentinelOne instance:
- Without `-t`: succeeds (falls back to the default 30s, comfortably
  above the ~11s the API currently needs to respond).
- With `-t 1`: fails fast with a timeout error, confirming the flag now
  actually controls the HTTP client timeout.